### PR TITLE
Fix docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,10 @@ services:
     ports:
       - "5050:80"
   api:
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: icog_api
-    image: icogapi:latest
     env_file: .env
     environment:
       PORT: 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
     container_name: icog_api
     env_file: .env
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 name: icog-psql-container
 services:
   db:

--- a/requirements.txt
+++ b/requirements.txt
@@ -100,3 +100,5 @@ weasel==0.3.4
 wheel==0.41.2
 widgetsnbextension==4.0.9
 openai==1.14.0
+sentence_transformers==2.7.0
+aiohttp==3.9.5


### PR DESCRIPTION
This fixes the docker compose file to build the image so you don't have to build manually and then start. A `docker compose up -d` should build and run the image in one command. Also enables hot reload so you don't have to restart the server when developing locally